### PR TITLE
bump forsuredbcompiler and forsuredbapi versions to 0.9.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -58,9 +58,9 @@ dependencies {
     compile 'com.android.support:appcompat-v7:23.4.0'
     compile 'com.android.support:recyclerview-v7:23.4.0'
 
-    provided 'com.fsryan.forsuredb:forsuredbcompiler:0.9.0'
+    provided 'com.fsryan.forsuredb:forsuredbcompiler:0.9.1'
 
     compile project(':forsuredbandroid')
 
-    apt 'com.fsryan.forsuredb:forsuredbcompiler:0.9.0'
+    apt 'com.fsryan.forsuredb:forsuredbcompiler:0.9.1'
 }

--- a/app/src/main/java/com/forsuredb/testapp/DocStoreTestActivity.java
+++ b/app/src/main/java/com/forsuredb/testapp/DocStoreTestActivity.java
@@ -221,7 +221,7 @@ public class DocStoreTestActivity extends AppCompatActivity implements TimePicke
             Log.i(LOG_TAG, "DocStoreIntPropertyExtensionLoader.onCreateLoader");
             return new FSCursorLoader<>(DocStoreTestActivity.this, docStoreTestTable()
                     .find()
-                            .byClassName(DocStoreIntPropertyExtension.class.getName())
+                            .byClass(DocStoreIntPropertyExtension.class)
                             .then()
                     .order()
                             .byModified(ORDER_DESC)
@@ -251,7 +251,7 @@ public class DocStoreTestActivity extends AppCompatActivity implements TimePicke
             Log.i(LOG_TAG, "DocStoreDoublePropertyExtensionLoader.onCreateLoader");
             return new FSCursorLoader<>(DocStoreTestActivity.this, docStoreTestTable()
                     .find()
-                            .byClassName(DocStoreDoublePropertyExtension.class.getName())
+                            .byClass(DocStoreDoublePropertyExtension.class)
                             .then()
                     .order()
                             .byModified(ORDER_DESC)

--- a/forsuredbandroid/build.gradle
+++ b/forsuredbandroid/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'android-maven'
 apply plugin: 'com.jfrog.bintray'
 
 group = 'com.fsryan.forsuredb'
-version = '0.9.0'
+version = '0.9.1'
 
 android {
     compileSdkVersion 23
@@ -47,7 +47,7 @@ dependencies {
 
     compile 'com.google.guava:guava:19.0'
 
-    compile 'com.fsryan.forsuredb:forsuredbapi:0.9.0'
+    compile 'com.fsryan.forsuredb:forsuredbapi:0.9.1'
     compile 'com.fsryan.forsuredb:sqlitelib:0.4.0'
 
     testCompile 'junit:junit:4.12'
@@ -110,10 +110,10 @@ bintray {
 //        publish = true
         publicDownloadNumbers = true
         version {
-            name = '0.9.0'
+            name = '0.9.1'
             desc = 'An android library leveraging the forsuredb project'
             released  = new Date()
-            vcsTag = 'v0.9.0'
+            vcsTag = 'v0.9.1'
         }
     }
 }


### PR DESCRIPTION
Changes demonstarted for Doc Store
- you can filter by Class object instead of fully-qualified class name
Changes demonstrated for querying API:
- joins can occur in any order along with find and orderby