### PR TITLE
instrumentation tests proving limit behaviors

### DIFF
--- a/forsuredbandroid/src/androidTest/java/com/fsryan/forsuredb/TestQueryUtil.java
+++ b/forsuredbandroid/src/androidTest/java/com/fsryan/forsuredb/TestQueryUtil.java
@@ -1,0 +1,109 @@
+package com.fsryan.forsuredb;
+
+import com.fsryan.forsuredb.api.FSOrdering;
+import com.fsryan.forsuredb.api.FSSelection;
+import com.fsryan.forsuredb.api.Limits;
+import com.fsryan.forsuredb.api.OrderBy;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class TestQueryUtil {
+
+    public static class SelectionBuilder {
+
+        private int limitCount = 0;
+        private int limitsOffset = 0;
+        private boolean limitFromBottom = false;
+        private String where = null;
+        private String[] replacements = null;
+
+        private SelectionBuilder() {}
+
+        public SelectionBuilder where(String where, String[] replacements) {
+            this.where = where;
+            this.replacements = replacements;
+            return this;
+        }
+
+        public SelectionBuilder limitFromBottom(boolean limitFromBottom) {
+            this.limitFromBottom = limitFromBottom;
+            return this;
+        }
+
+        public SelectionBuilder limitCount(int limitCount) {
+            this.limitCount = limitCount;
+            return this;
+        }
+
+        public SelectionBuilder offset(int offset) {
+            this.limitsOffset = offset;
+            return this;
+        }
+
+        public FSSelection build() {
+            return new FSSelection() {
+                @Override
+                public String where() {
+                    return where;
+                }
+
+                @Override
+                public String[] replacements() {
+                    return replacements;
+                }
+
+                @Override
+                public Limits limits() {
+                    if (!limitFromBottom && limitCount == 0 && limitsOffset == 0) {
+                        return null;
+                    }
+                    return new Limits() {
+                        @Override
+                        public int count() {
+                            return limitCount;
+                        }
+
+                        @Override
+                        public int offset() {
+                            return limitsOffset;
+                        }
+
+                        @Override
+                        public boolean isBottom() {
+                            return limitFromBottom;
+                        }
+                    };
+                }
+            };
+        }
+    }
+
+    public static SelectionBuilder selection() {
+        return new SelectionBuilder();
+    }
+
+    public static FSSelection idSelection(long id) {
+        return selection().where("_id=?", new String[] {Long.toString(id)}).build();
+    }
+
+    public static List<FSOrdering> orderings(FSOrdering... orderings) {
+        return orderings == null ? null : Arrays.asList(orderings);
+    }
+
+    public static FSOrdering idOrderingASC(String table) {
+        return orderingASC(table, "_id");
+    }
+
+    public static FSOrdering idOrderingDESC(String table) {
+        return orderingDESC(table, "_id");
+    }
+
+    public static FSOrdering orderingASC(String table, String column) {
+        return new FSOrdering(table, column, OrderBy.ORDER_ASC);
+    }
+
+    public static FSOrdering orderingDESC(String table, String column) {
+        return new FSOrdering(table, column, OrderBy.ORDER_DESC);
+    }
+}

--- a/forsuredbandroid/src/androidTest/java/com/fsryan/forsuredb/queryable/BasicQueryableTestsWithSeedDataInAssets.java
+++ b/forsuredbandroid/src/androidTest/java/com/fsryan/forsuredb/queryable/BasicQueryableTestsWithSeedDataInAssets.java
@@ -2,34 +2,40 @@ package com.fsryan.forsuredb.queryable;
 
 import android.content.ContentValues;
 import android.support.v4.util.Pair;
+import android.util.Log;
 
 import com.fsryan.forsuredb.api.FSJoin;
 import com.fsryan.forsuredb.api.FSProjection;
 import com.fsryan.forsuredb.api.FSQueryable;
 import com.fsryan.forsuredb.api.FSSelection;
-import com.fsryan.forsuredb.api.Limits;
 import com.fsryan.forsuredb.api.Retriever;
 import com.fsryan.forsuredb.api.SaveResult;
 import com.google.common.collect.ImmutableMap;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
+import static com.fsryan.forsuredb.TestQueryUtil.idOrderingASC;
+import static com.fsryan.forsuredb.TestQueryUtil.idSelection;
+import static com.fsryan.forsuredb.TestQueryUtil.orderings;
+import static com.fsryan.forsuredb.TestQueryUtil.selection;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public abstract class BasicQueryableTestsWithSeedDataInAssets<L> extends BaseQueryableTest {
 
-    /*package*/ static final double ACCEPTABLE_DELTA = 0.000001D;
+    static final double ACCEPTABLE_DELTA = 0.000001D;
 
-    /*package*/ static final String[] userTableColumns = new String[] {
+    static final String[] userTableColumns = new String[] {
             "_id",
             "app_rating",
             "competitor_app_rating",
@@ -38,7 +44,7 @@ public abstract class BasicQueryableTestsWithSeedDataInAssets<L> extends BaseQue
             "login_count",
             "modified"
     };
-    /*package*/ static final String[] profileInfoTableColumns = new String[] {
+    static final String[] profileInfoTableColumns = new String[] {
             "_id",
             "awesome",
             "binary_data",
@@ -61,6 +67,9 @@ public abstract class BasicQueryableTestsWithSeedDataInAssets<L> extends BaseQue
     private static final boolean standardProfileInfoAwesome = true;
     private static final byte[] standardProfileInfoBinaryData = new byte[] {19, 85, 3, 11};
 
+    @Rule
+    public TestName testName = new TestName();
+
     private Retriever r;
 
     @Before
@@ -81,7 +90,7 @@ public abstract class BasicQueryableTestsWithSeedDataInAssets<L> extends BaseQue
 
         r = createQueryable(userRecordLocator(1L)).query(userTableProjection(), null, null);
 
-        assertUserValueInCursorAtPosition(r, 0, standardUserAppRating, standardUserCompetitorAppRating, standardUserGlobalId, standardUserLoginCount);
+        assertUserValueInCursorAtPosition(r, 0, 1L, standardUserAppRating, standardUserCompetitorAppRating, standardUserGlobalId, standardUserLoginCount);
     }
 
     @Test
@@ -93,7 +102,7 @@ public abstract class BasicQueryableTestsWithSeedDataInAssets<L> extends BaseQue
         assertEquals(1, rowsAffected);
 
         r = createQueryable(userRecordLocator(1L)).query(userTableProjection(), null, null);
-        assertUserValueInCursorAtPosition(r, 0, 3.1, BigDecimal.ONE, 2L, 3);
+        assertUserValueInCursorAtPosition(r, 0, 1L, 3.1, BigDecimal.ONE, 2L, 3);
     }
 
     @Test
@@ -114,7 +123,7 @@ public abstract class BasicQueryableTestsWithSeedDataInAssets<L> extends BaseQue
         List<FSProjection> projections = Arrays.asList(profileInfoTableProjection(), userTableProjection());
 
         r = createQueryable(toQuery).query(joins, projections, null, null);
-        assertUserValueInCursorAtPosition(r, 0, standardUserAppRating, standardUserCompetitorAppRating, standardUserGlobalId, standardUserLoginCount);
+        assertUserValueInCursorAtPosition(r, 0, 1L, standardUserAppRating, standardUserCompetitorAppRating, standardUserGlobalId, standardUserLoginCount);
         assertProfileInfoValueInCursorAtPosition(r, 0, standardProfileInfoUserId, standardProfileInfoEmailAddress, standardProfileInfoUuid, standardProfileInfoAwesome, standardProfileInfoBinaryData);
     }
 
@@ -124,12 +133,12 @@ public abstract class BasicQueryableTestsWithSeedDataInAssets<L> extends BaseQue
 
         final FSContentValues update = new FSContentValues(userCV(3.1, BigDecimal.ONE, 2L, 3));
         // id 2 does not exist in database yet
-        SaveResult<L> result = createQueryable(userTableLocator()).upsert(update, createIdSelection(2L), null);
+        SaveResult<L> result = createQueryable(userTableLocator()).upsert(update, idSelection(2L), null);
         assertEquals(1, result.rowsAffected());
 
         r = createQueryable(userTableLocator()).query(userTableProjection(),null, null);
-        assertUserValueInCursorAtPosition(r, 0, standardUserAppRating, standardUserCompetitorAppRating, standardUserGlobalId, standardUserLoginCount);
-        assertUserValueInCursorAtPosition(r, 1, 3.1, BigDecimal.ONE, 2L, 3);
+        assertUserValueInCursorAtPosition(r, 0, 1L, standardUserAppRating, standardUserCompetitorAppRating, standardUserGlobalId, standardUserLoginCount);
+        assertUserValueInCursorAtPosition(r, 1, 2L, 3.1, BigDecimal.ONE, 2L, 3);
     }
 
     @Test
@@ -138,12 +147,392 @@ public abstract class BasicQueryableTestsWithSeedDataInAssets<L> extends BaseQue
 
         final FSContentValues update = new FSContentValues(userCV(3.1, BigDecimal.ONE, 2L, 3));
         // id 1 was just inserted above
-        SaveResult<L> result = createQueryable(userTableLocator()).upsert(update, createIdSelection(1L), null);
+        SaveResult<L> result = createQueryable(userTableLocator()).upsert(update, idSelection(1L), null);
         assertEquals(1, result.rowsAffected());
 
-        r = createQueryable(userTableLocator()).query(userTableProjection(), createIdSelection(1L), null);
-        assertUserValueInCursorAtPosition(r, 0, 3.1, BigDecimal.ONE, 2L, 3);
+        r = createQueryable(userTableLocator()).query(userTableProjection(), idSelection(1L), null);
+        assertUserValueInCursorAtPosition(r, 0, 1L, 3.1, BigDecimal.ONE, 2L, 3);
     }
+
+    @Test
+    public void shouldCorectlyLimitOnRetrievalQueryFromTop() {
+        insertConsecutivelyIncreasingValuedUsers(4);
+
+        FSSelection selection = selection().limitCount(2).build();
+        r = createQueryable(userTableLocator()).query(userTableProjection(), selection, orderings(idOrderingASC("user")));
+
+        assertUserValueInCursorAtPosition(
+                r,
+                0,
+                1L,
+                standardUserAppRating,
+                standardUserCompetitorAppRating,
+                standardUserGlobalId,
+                standardUserLoginCount
+        );
+        assertUserValueInCursorAtPosition(
+                r,
+                1,
+                2L,
+                standardUserAppRating + 1,
+                standardUserCompetitorAppRating.add(BigDecimal.ONE),
+                standardUserGlobalId + 1,
+                standardUserLoginCount + 1
+        );
+        assertEquals(2, r.getCount());
+    }
+
+    @Test
+    public void shouldCorectlyLimitOnRetrievalQueryFromBottom() {
+        insertConsecutivelyIncreasingValuedUsers(4);
+
+        FSSelection selection = selection().limitCount(2).limitFromBottom(true).build();
+        r = createQueryable(userTableLocator()).query(userTableProjection(), selection, orderings(idOrderingASC("user")));
+
+        assertUserValueInCursorAtPosition(
+                r,
+                0,
+                3L,
+                standardUserAppRating + 2,
+                standardUserCompetitorAppRating.add(new BigDecimal(2)),
+                standardUserGlobalId + 2,
+                standardUserLoginCount + 2
+        );
+        assertUserValueInCursorAtPosition(
+                r,
+                1,
+                4L,
+                standardUserAppRating + 3,
+                standardUserCompetitorAppRating.add(new BigDecimal(3)),
+                standardUserGlobalId + 3,
+                standardUserLoginCount + 3
+        );
+        assertEquals(2, r.getCount());
+    }
+
+    @Test
+    public void shouldCorrectlyOffsetQueryWithoutLimitFromTop() {
+        insertConsecutivelyIncreasingValuedUsers(4);
+
+        FSSelection selection = selection().offset(1).build();
+        r = createQueryable(userTableLocator()).query(userTableProjection(), selection, orderings(idOrderingASC("user")));
+
+        assertUserValueInCursorAtPosition(
+                r,
+                0,
+                2L,
+                standardUserAppRating + 1,
+                standardUserCompetitorAppRating.add(BigDecimal.ONE),
+                standardUserGlobalId + 1,
+                standardUserLoginCount + 1
+        );
+        assertUserValueInCursorAtPosition(
+                r,
+                1,
+                3L,
+                standardUserAppRating + 2,
+                standardUserCompetitorAppRating.add(new BigDecimal(2)),
+                standardUserGlobalId + 2,
+                standardUserLoginCount + 2
+        );
+        assertUserValueInCursorAtPosition(
+                r,
+                2,
+                4L,
+                standardUserAppRating + 3,
+                standardUserCompetitorAppRating.add(new BigDecimal(3)),
+                standardUserGlobalId + 3,
+                standardUserLoginCount + 3
+        );
+        assertEquals(3, r.getCount());
+    }
+
+    @Test
+    public void shouldCorrectlyOffsetQueryWithoutLimitFromBottom() {
+        insertConsecutivelyIncreasingValuedUsers(4);
+
+        FSSelection selection = selection().offset(1).limitFromBottom(true).build();
+        r = createQueryable(userTableLocator()).query(userTableProjection(), selection, orderings(idOrderingASC("user")));
+
+        assertUserValueInCursorAtPosition(
+                r,
+                0,
+                1L,
+                standardUserAppRating,
+                standardUserCompetitorAppRating,
+                standardUserGlobalId,
+                standardUserLoginCount
+        );
+        assertUserValueInCursorAtPosition(
+                r,
+                1,
+                2L,
+                standardUserAppRating + 1,
+                standardUserCompetitorAppRating.add(BigDecimal.ONE),
+                standardUserGlobalId + 1,
+                standardUserLoginCount + 1
+        );
+        assertUserValueInCursorAtPosition(
+                r,
+                2,
+                3L,
+                standardUserAppRating + 2,
+                standardUserCompetitorAppRating.add(new BigDecimal(2)),
+                standardUserGlobalId + 2,
+                standardUserLoginCount + 2
+        );
+        assertEquals(3, r.getCount());
+    }
+
+    @Test
+    public void shouldCorrectlyOffsetQueryWithLimitFromTop() {
+        insertConsecutivelyIncreasingValuedUsers(4);
+
+        FSSelection selection = selection().offset(1).limitCount(2).build();
+        r = createQueryable(userTableLocator()).query(userTableProjection(), selection, orderings(idOrderingASC("user")));
+
+        assertUserValueInCursorAtPosition(
+                r,
+                0,
+                2L,
+                standardUserAppRating + 1,
+                standardUserCompetitorAppRating.add(BigDecimal.ONE),
+                standardUserGlobalId + 1,
+                standardUserLoginCount + 1
+        );
+        assertUserValueInCursorAtPosition(
+                r,
+                1,
+                3L,
+                standardUserAppRating + 2,
+                standardUserCompetitorAppRating.add(new BigDecimal(2)),
+                standardUserGlobalId + 2,
+                standardUserLoginCount + 2
+        );
+        assertEquals(2, r.getCount());
+    }
+
+    @Test
+    public void shouldCorrectlyOffsetQueryWithLimitFromBottom() {
+        insertConsecutivelyIncreasingValuedUsers(4);
+
+        FSSelection selection = selection().offset(1).limitCount(2).limitFromBottom(true).build();
+        r = createQueryable(userTableLocator()).query(userTableProjection(), selection, orderings(idOrderingASC("user")));
+
+        assertUserValueInCursorAtPosition(
+                r,
+                0,
+                2L,
+                standardUserAppRating + 1,
+                standardUserCompetitorAppRating.add(BigDecimal.ONE),
+                standardUserGlobalId + 1,
+                standardUserLoginCount + 1
+        );
+        assertUserValueInCursorAtPosition(
+                r,
+                1,
+                3L,
+                standardUserAppRating + 2,
+                standardUserCompetitorAppRating.add(new BigDecimal(2)),
+                standardUserGlobalId + 2,
+                standardUserLoginCount + 2
+        );
+        assertEquals(2, r.getCount());
+    }
+
+    @Test
+    public void shouldCorectlyLimitOnRetrievalJoinQueryFromTop() {
+        insertConsecutivelyIncreasingValuedUsers(4, true);
+
+        FSSelection selection = selection().limitCount(2).build();
+        r = createQueryable(userProfileInfoJoinLocator())
+                .query(userProfileInfoJoin(), userProfileInfoJoinProjections(), selection, orderings(idOrderingASC("user")));
+
+        assertUserValueInCursorAtPosition(
+                r,
+                0,
+                1L,
+                standardUserAppRating,
+                standardUserCompetitorAppRating,
+                standardUserGlobalId,
+                standardUserLoginCount
+        );
+        assertUserValueInCursorAtPosition(
+                r,
+                1,
+                2L,
+                standardUserAppRating + 1,
+                standardUserCompetitorAppRating.add(BigDecimal.ONE),
+                standardUserGlobalId + 1,
+                standardUserLoginCount + 1
+        );
+        assertEquals(2, r.getCount());
+    }
+
+    @Test
+    public void shouldCorectlyLimitOnRetrievalJoinQueryFromBottom() {
+        insertConsecutivelyIncreasingValuedUsers(4, true);
+
+        FSSelection selection = selection().limitCount(2).limitFromBottom(true).build();
+        r = createQueryable(userProfileInfoJoinLocator())
+                .query(userProfileInfoJoin(), userProfileInfoJoinProjections(), selection, orderings(idOrderingASC("user")));
+
+        assertUserValueInCursorAtPosition(
+                r,
+                0,
+                3L,
+                standardUserAppRating + 2,
+                standardUserCompetitorAppRating.add(new BigDecimal(2)),
+                standardUserGlobalId + 2,
+                standardUserLoginCount + 2
+        );
+        assertUserValueInCursorAtPosition(
+                r,
+                1,
+                4L,
+                standardUserAppRating + 3,
+                standardUserCompetitorAppRating.add(new BigDecimal(3)),
+                standardUserGlobalId + 3,
+                standardUserLoginCount + 3
+        );
+        assertEquals(2, r.getCount());
+    }
+
+    @Test
+    public void shouldCorrectlyOffsetJoinQueryWithoutLimitFromTop() {
+        insertConsecutivelyIncreasingValuedUsers(4, true);
+
+        FSSelection selection = selection().offset(1).build();
+        r = createQueryable(userProfileInfoJoinLocator())
+                .query(userProfileInfoJoin(), userProfileInfoJoinProjections(), selection, orderings(idOrderingASC("user")));
+
+        assertUserValueInCursorAtPosition(
+                r,
+                0,
+                2L,
+                standardUserAppRating + 1,
+                standardUserCompetitorAppRating.add(BigDecimal.ONE),
+                standardUserGlobalId + 1,
+                standardUserLoginCount + 1
+        );
+        assertUserValueInCursorAtPosition(
+                r,
+                1,
+                3L,
+                standardUserAppRating + 2,
+                standardUserCompetitorAppRating.add(new BigDecimal(2)),
+                standardUserGlobalId + 2,
+                standardUserLoginCount + 2
+        );
+        assertUserValueInCursorAtPosition(
+                r,
+                2,
+                4L,
+                standardUserAppRating + 3,
+                standardUserCompetitorAppRating.add(new BigDecimal(3)),
+                standardUserGlobalId + 3,
+                standardUserLoginCount + 3
+        );
+        assertEquals(3, r.getCount());
+    }
+
+    @Test
+    public void shouldCorrectlyOffsetJoinQueryWithoutLimitFromBottom() {
+        insertConsecutivelyIncreasingValuedUsers(4, true);
+
+        FSSelection selection = selection().offset(1).limitFromBottom(true).build();
+        r = createQueryable(userProfileInfoJoinLocator())
+                .query(userProfileInfoJoin(), userProfileInfoJoinProjections(), selection, orderings(idOrderingASC("user")));
+
+        assertUserValueInCursorAtPosition(
+                r,
+                0,
+                1L,
+                standardUserAppRating,
+                standardUserCompetitorAppRating,
+                standardUserGlobalId,
+                standardUserLoginCount
+        );
+        assertUserValueInCursorAtPosition(
+                r,
+                1,
+                2L,
+                standardUserAppRating + 1,
+                standardUserCompetitorAppRating.add(BigDecimal.ONE),
+                standardUserGlobalId + 1,
+                standardUserLoginCount + 1
+        );
+        assertUserValueInCursorAtPosition(
+                r,
+                2,
+                3L,
+                standardUserAppRating + 2,
+                standardUserCompetitorAppRating.add(new BigDecimal(2)),
+                standardUserGlobalId + 2,
+                standardUserLoginCount + 2
+        );
+        assertEquals(3, r.getCount());
+    }
+
+    @Test
+    public void shouldCorrectlyOffsetJoinQueryWithLimitFromTop() {
+        insertConsecutivelyIncreasingValuedUsers(4, true);
+
+        FSSelection selection = selection().offset(1).limitCount(2).build();
+        r = createQueryable(userProfileInfoJoinLocator())
+                .query(userProfileInfoJoin(), userProfileInfoJoinProjections(), selection, orderings(idOrderingASC("user")));
+
+        assertUserValueInCursorAtPosition(
+                r,
+                0,
+                2L,
+                standardUserAppRating + 1,
+                standardUserCompetitorAppRating.add(BigDecimal.ONE),
+                standardUserGlobalId + 1,
+                standardUserLoginCount + 1
+        );
+        assertUserValueInCursorAtPosition(
+                r,
+                1,
+                3L,
+                standardUserAppRating + 2,
+                standardUserCompetitorAppRating.add(new BigDecimal(2)),
+                standardUserGlobalId + 2,
+                standardUserLoginCount + 2
+        );
+        assertEquals(2, r.getCount());
+    }
+
+    @Test
+    public void shouldCorrectlyOffsetJoinQueryWithLimitFromBottom() {
+        insertConsecutivelyIncreasingValuedUsers(4, true);
+
+        FSSelection selection = selection().offset(1).limitCount(2).limitFromBottom(true).build();
+        r = createQueryable(userProfileInfoJoinLocator())
+                .query(userProfileInfoJoin(), userProfileInfoJoinProjections(), selection, orderings(idOrderingASC("user")));
+
+        assertUserValueInCursorAtPosition(
+                r,
+                0,
+                2L,
+                standardUserAppRating + 1,
+                standardUserCompetitorAppRating.add(BigDecimal.ONE),
+                standardUserGlobalId + 1,
+                standardUserLoginCount + 1
+        );
+        assertUserValueInCursorAtPosition(
+                r,
+                1,
+                3L,
+                standardUserAppRating + 2,
+                standardUserCompetitorAppRating.add(new BigDecimal(2)),
+                standardUserGlobalId + 2,
+                standardUserLoginCount + 2
+        );
+        assertEquals(2, r.getCount());
+    }
+
+    protected abstract long idFrom(L insertedRecord);
 
     protected abstract FSQueryable<L, FSContentValues> createQueryable(L locator);
 
@@ -151,12 +540,12 @@ public abstract class BasicQueryableTestsWithSeedDataInAssets<L> extends BaseQue
 
     protected abstract L tableLocator(String table, Pair<String, String>... joinStringKVPair);
 
-    private static void assertUserValueInCursorAtPosition(Retriever r, int position, double appRating, BigDecimal competitorAppRating, long globalId, int loginCount) {
-        assertTrue(r.moveToPosition(position));
-        assertEquals(appRating, r.getDouble("user_app_rating"), ACCEPTABLE_DELTA);
-        assertEquals(competitorAppRating.toString(), r.getString("user_competitor_app_rating"));
-        assertEquals(globalId, r.getLong("user_global_id"));
-        assertEquals(loginCount, r.getInt("user_login_count"));
+    private static List<FSProjection> userProfileInfoJoinProjections() {
+        return Arrays.asList(profileInfoTableProjection(), userTableProjection());
+    }
+
+    private static List<FSJoin> userProfileInfoJoin() {
+        return Arrays.asList(new FSJoin(FSJoin.Type.INNER, "user", "profile_info", ImmutableMap.of("user_id", "_id")));
     }
 
     private static ContentValues userCV(double appRating, BigDecimal competitorAppRating, long globalId, int loginCount) {
@@ -166,15 +555,6 @@ public abstract class BasicQueryableTestsWithSeedDataInAssets<L> extends BaseQue
         ret.put("global_id", globalId);
         ret.put("login_count", loginCount);
         return ret;
-    }
-
-    private void assertProfileInfoValueInCursorAtPosition(Retriever c, int position, long userId, String emailAddress, String uuid, boolean awesome, byte[] binaryData) {
-        assertTrue(c.moveToPosition(position));
-        assertEquals(userId, c.getLong("profile_info_user_id"));
-        assertEquals(emailAddress, c.getString("profile_info_email_address"));
-        assertEquals(uuid, c.getString("profile_info_uuid"));
-        assertEquals(awesome ? 1 : 0, c.getInt("profile_info_awesome"));
-        assertArrayEquals(binaryData, c.getBytes("profile_info_binary_data"));
     }
 
     private static ContentValues profileInfoCV(long userId, String emailAddress, String uuid, boolean awesome, byte[] binaryData) {
@@ -233,23 +613,62 @@ public abstract class BasicQueryableTestsWithSeedDataInAssets<L> extends BaseQue
         };
     }
 
-    private static FSSelection createIdSelection(final long id) {
-        return new FSSelection() {
-            @Override
-            public String where() {
-                return "_id=?";
-            }
+    private void assertUserValueInCursorAtPosition(Retriever r, int position, long expectedId, double expectedAppRating, BigDecimal expectedCompetitorAppRating, long expectedGlobalId, int expectedLoginCount) {
+        assertTrue(r.moveToPosition(position));
+        long actualId = r.getLong("user__id");
+        double actualAppRating = r.getDouble("user_app_rating");
+        BigDecimal actualCompetitorAppRating = new BigDecimal(r.getString("user_competitor_app_rating"));
+        long actualGlobalId = r.getLong("user_global_id");
+        int actualLoginCount = r.getInt("user_login_count");
 
-            @Override
-            public String[] replacements() {
-                return new String[] {Long.toString(id)};
-            }
+        Log.i("QUERY_CHECK", testName.getMethodName() + ": position = " + position
+                + "\n\t_id = " + actualId + ", expected = " + expectedId
+                + "\n\tuser_app_rating = " + actualAppRating + ", expected " + expectedAppRating
+                + "\n\tuser_competitor_app_rating = " + actualCompetitorAppRating + ", expected = " + expectedCompetitorAppRating
+                + "\n\tuser_global_id = " + actualGlobalId + ", expected = " + expectedGlobalId
+                + "\n\tuser_login_count = " + actualLoginCount + ", expected = " + expectedLoginCount);
 
-            @Override
-            public Limits limits() {
-                return null;
+        assertEquals(expectedId, actualId);
+        assertEquals(expectedAppRating, actualAppRating, ACCEPTABLE_DELTA);
+        assertEquals(expectedCompetitorAppRating, actualCompetitorAppRating);
+        assertEquals(expectedGlobalId, actualGlobalId);
+        assertEquals(expectedLoginCount, actualLoginCount);
+    }
+
+    private L userProfileInfoJoinLocator() {
+        return profileInfoTableLocator(new Pair<>("INNER JOIN", "user ON user._id = profile_info.user_id"));
+    }
+
+    private void insertConsecutivelyIncreasingValuedUsers(int count) {
+        insertConsecutivelyIncreasingValuedUsers(count, false);
+    }
+
+    private void insertConsecutivelyIncreasingValuedUsers(int count, boolean createProfileInfo) {
+        double appRating = standardUserAppRating;
+        BigDecimal competitorAppRating = standardUserCompetitorAppRating;
+        long globalId = standardUserGlobalId;
+        int loginCount = standardUserLoginCount;
+        for (int i = 0; i < count; i++) {
+            L inserted = insertUser(appRating, competitorAppRating, globalId, loginCount);
+            if (createProfileInfo) {
+                long userId = idFrom(inserted);
+                String email = "user" + userId + "@email.com";
+                insertProfileInfo(userId, email, email, userId % 2 == 0, new byte[] {(byte) (userId & 0x000000FF)});
             }
-        };
+            appRating += 1;
+            competitorAppRating = competitorAppRating.add(BigDecimal.ONE);
+            globalId += 1;
+            loginCount += 1;
+        }
+    }
+
+    private void assertProfileInfoValueInCursorAtPosition(Retriever c, int position, long userId, String emailAddress, String uuid, boolean awesome, byte[] binaryData) {
+        assertTrue(c.moveToPosition(position));
+        assertEquals(userId, c.getLong("profile_info_user_id"));
+        assertEquals(emailAddress, c.getString("profile_info_email_address"));
+        assertEquals(uuid, c.getString("profile_info_uuid"));
+        assertEquals(awesome ? 1 : 0, c.getInt("profile_info_awesome"));
+        assertArrayEquals(binaryData, c.getBytes("profile_info_binary_data"));
     }
 
     private L insertStandardUser() {

--- a/forsuredbandroid/src/androidTestContentProvider/java/com/fsryan/forsuredb/queryable/ContentProviderQueryableTest.java
+++ b/forsuredbandroid/src/androidTestContentProvider/java/com/fsryan/forsuredb/queryable/ContentProviderQueryableTest.java
@@ -50,6 +50,11 @@ public class ContentProviderQueryableTest extends BasicQueryableTestsWithSeedDat
     }
 
     @Override
+    protected long idFrom(Uri insertedRecord) {
+        return Long.parseLong(insertedRecord.getLastPathSegment());
+    }
+
+    @Override
     protected FSQueryable<Uri, FSContentValues> createQueryable(Uri locator) {
         return new ContentProviderQueryable(getTargetContext(), locator);
     }

--- a/forsuredbandroid/src/androidTestDirectDB/java/com/fsryan/forsuredb/queryable/SQLiteDBQueryableTest.java
+++ b/forsuredbandroid/src/androidTestDirectDB/java/com/fsryan/forsuredb/queryable/SQLiteDBQueryableTest.java
@@ -11,8 +11,10 @@ import org.junit.runner.RunWith;
 @RunWith(AndroidJUnit4.class)
 public class SQLiteDBQueryableTest extends BasicQueryableTestsWithSeedDataInAssets<DirectLocator> {
 
-    @Test
-    public void should() {}
+    @Override
+    protected long idFrom(DirectLocator insertedRecord) {
+        return insertedRecord.id;
+    }
 
     @Override
     protected FSQueryable<DirectLocator, FSContentValues> createQueryable(DirectLocator locator) {

--- a/forsuredbandroid/src/contentProvider/java/com/fsryan/forsuredb/queryable/ContentProviderQueryable.java
+++ b/forsuredbandroid/src/contentProvider/java/com/fsryan/forsuredb/queryable/ContentProviderQueryable.java
@@ -40,9 +40,9 @@ import java.util.List;
 
 import static com.fsryan.forsuredb.queryable.ProjectionHelper.formatProjection;
 import static com.fsryan.forsuredb.queryable.ProjectionHelper.isDistinct;
-import static com.fsryan.forsuredb.queryable.UriEvaluator.FIRST_QUERY_PARAM;
+import static com.fsryan.forsuredb.queryable.UriEvaluator.FROM_BOTTOM_QUERY_PARAM;
+import static com.fsryan.forsuredb.queryable.UriEvaluator.LIMIT_QUERY_PARAM;
 import static com.fsryan.forsuredb.queryable.UriEvaluator.OFFSET_QUERY_PARAM;
-import static com.fsryan.forsuredb.queryable.UriEvaluator.LAST_QUERY_PARAM;
 import static com.fsryan.forsuredb.queryable.UriEvaluator.ORDER_BY_QUERY_PARM;
 
 public class ContentProviderQueryable implements FSQueryable<Uri, FSContentValues> {
@@ -158,12 +158,15 @@ public class ContentProviderQueryable implements FSQueryable<Uri, FSContentValue
             builder.appendQueryParameter("UPSERT", "true");
         }
 
-        if (limits.offset() > 0 || limits.count() > 0) {
-            final String limitType = limits.isBottom() ? LAST_QUERY_PARAM : FIRST_QUERY_PARAM;
-            builder.appendQueryParameter(limitType, String.valueOf(limits.count()))
-                    .appendQueryParameter(OFFSET_QUERY_PARAM, String.valueOf(limits.offset()));
+        if (limits.offset() > 0) {
+            builder.appendQueryParameter(OFFSET_QUERY_PARAM, String.valueOf(limits.offset()));
         }
-
+        if (limits.count() > 0) {
+            builder.appendQueryParameter(LIMIT_QUERY_PARAM, String.valueOf(limits.count()));
+        }
+        if (limits.isBottom()) {
+            builder.appendQueryParameter(FROM_BOTTOM_QUERY_PARAM, "");
+        }
         if (!orderings.isEmpty()) {
             builder.appendQueryParameter(ORDER_BY_QUERY_PARM, Sql.generator().expressOrdering(orderings));
         }

--- a/forsuredbandroid/src/contentProvider/java/com/fsryan/forsuredb/queryable/UriEvaluator.java
+++ b/forsuredbandroid/src/contentProvider/java/com/fsryan/forsuredb/queryable/UriEvaluator.java
@@ -37,8 +37,8 @@ import java.util.Set;
 public class UriEvaluator {
 
     public static final String DISTINCT_QUERY_PARAM = "DISTINCT";
-    public static final String LAST_QUERY_PARAM = "LAST";
-    public static final String FIRST_QUERY_PARAM = "FIRST";
+    public static final String FROM_BOTTOM_QUERY_PARAM = "FROM_BOTTOM";
+    public static final String LIMIT_QUERY_PARAM = "LIMIT";
     public static final String OFFSET_QUERY_PARAM = "OFFSET";
     public static final String ORDER_BY_QUERY_PARM = "ORDER_BY";
 
@@ -103,11 +103,9 @@ public class UriEvaluator {
         return false;
     }
 
-    public static boolean hasFirstOrLastParam(@NonNull Uri uri) {
+    public static boolean isLimitingOrOffsetting(@NonNull Uri uri) {
         final Set<String> names = uri.getQueryParameterNames();
-        return names.contains(FIRST_QUERY_PARAM)
-                || names.contains(LAST_QUERY_PARAM)
-                || names.contains(OFFSET_QUERY_PARAM);
+        return names.contains(LIMIT_QUERY_PARAM) || names.contains(OFFSET_QUERY_PARAM);
     }
 
     public static int offsetFrom(@NonNull Uri uri) {
@@ -116,15 +114,12 @@ public class UriEvaluator {
     }
 
     public static int limitFrom(@NonNull Uri uri) {
-        String offset = uri.getQueryParameter(FIRST_QUERY_PARAM);
-        offset = offset == null ? uri.getQueryParameter(LAST_QUERY_PARAM) : offset;
+        String offset = uri.getQueryParameter(LIMIT_QUERY_PARAM);
         return offset == null ? 0 : Integer.parseInt(offset);
     }
 
-    public static boolean offsetFromLast(@NonNull Uri uri) {
-        String offset = uri.getQueryParameter(FIRST_QUERY_PARAM);
-        int frontOffset = offset == null ? 0 : Integer.parseInt(offset);
-        return frontOffset <= 0 && limitFrom(uri) > 0;
+    public static boolean queryFromBottom(@NonNull Uri uri) {
+        return uri.getQueryParameter(FROM_BOTTOM_QUERY_PARAM) != null;
     }
 
     @NonNull

--- a/forsuredbandroid/src/contentProvider/java/com/fsryan/forsuredb/queryable/UriQueryCorrector.java
+++ b/forsuredbandroid/src/contentProvider/java/com/fsryan/forsuredb/queryable/UriQueryCorrector.java
@@ -11,11 +11,11 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import static com.fsryan.forsuredb.queryable.UriEvaluator.queryFromBottom;
 import static com.fsryan.forsuredb.queryable.UriJoinTranslator.joinStringFrom;
 import static com.fsryan.forsuredb.queryable.UriEvaluator.isSpecificRecordUri;
 import static com.fsryan.forsuredb.queryable.UriEvaluator.limitFrom;
 import static com.fsryan.forsuredb.queryable.UriEvaluator.offsetFrom;
-import static com.fsryan.forsuredb.queryable.UriEvaluator.offsetFromLast;
 import static com.fsryan.forsuredb.queryable.UriEvaluator.orderingFrom;
 
 /*package*/ class UriQueryCorrector extends QueryCorrector {
@@ -32,7 +32,7 @@ import static com.fsryan.forsuredb.queryable.UriEvaluator.orderingFrom;
                 orderingFrom(uri),
                 offsetFrom(uri),
                 limitFrom(uri),
-                offsetFromLast(uri)
+                queryFromBottom(uri)
         );
     }
 

--- a/forsuredbandroid/src/main/java/com/fsryan/forsuredb/queryable/QueryCorrector.java
+++ b/forsuredbandroid/src/main/java/com/fsryan/forsuredb/queryable/QueryCorrector.java
@@ -39,6 +39,8 @@ import java.util.Set;
  */
 /*package*/ class QueryCorrector {
 
+    static final int LIMIT_OFFSET_NO_LIMIT = -1;
+
     private final String tableName;
     private final String joinString;
     private final String where;
@@ -94,7 +96,11 @@ import java.util.Set;
     }
 
     public int getLimit() {
-        return limit;
+        return offset > 0 && limit == 0 ? LIMIT_OFFSET_NO_LIMIT : limit;
+    }
+
+    public boolean isFindingLast() {
+        return findingLast;
     }
 
     @NonNull
@@ -117,7 +123,7 @@ import java.util.Set;
                 + (orderBy.isEmpty()
                         ?  tableName + "._id " + (findingLast ? "DESC" : "ASC")
                         : (findingLast ? flipOrderBy() : orderBy).trim())
-                + (limit > 0 ? " LIMIT " + limit : "")
+                + (getLimit() != 0 ? " LIMIT " + getLimit() : "")
                 + (offset > 0 ? " OFFSET " + offset : "")
                 + ")";
     }

--- a/forsuredbandroid/src/testContentProvider/java/com/fsryan/forsuredb/queryable/UriQueryCorrectorTest.java
+++ b/forsuredbandroid/src/testContentProvider/java/com/fsryan/forsuredb/queryable/UriQueryCorrectorTest.java
@@ -181,7 +181,7 @@ public abstract class UriQueryCorrectorTest {
                     {   // 00: no limit or offset case
                             new MockUriBuilder("table")
                                     .orderBy(" ORDER BY table.column ASC")
-                                    .build(),                  // inputUri
+                                    .build(),                                   // inputUri
                             "",                                                 // expectedSelectionRetrieval
                             "",                                                 // expectedSelectionEdit
                             new String[0],                                      // expectedSelectionArgs
@@ -189,207 +189,214 @@ public abstract class UriQueryCorrectorTest {
                             0,                                                  // expectedOffset
                             0                                                   // expectedLimit
                     },
-                    {   // 01: limit provided by first with no offset--should NOT flip ordering in inner select for update/delete query
+                    {   // 01: limit provided by limit with no offset--should NOT flip ordering in inner select for update/delete query
                             new MockUriBuilder("table")
-                                    .first(10)
+                                    .limit(10)
                                     .orderBy(" ORDER BY table.column ASC")
-                                    .build(),                                                  // inputUri
-                            "",                                                                                 // expectedSelectionRetrieval
+                                    .build(),                                                                       // inputUri
+                            "",                                                                                     // expectedSelectionRetrieval
                             "table.rowid IN (SELECT table.rowid FROM table ORDER BY table.column ASC LIMIT 10)",    // expectedSelectionEdit
-                            new String[0],                                                                      // expectedSelectionArgs
-                            "table.column ASC",                                                                 // expectedOrderBy
-                            0,                                                                                  // expectedOffset
-                            10                                                                                  // expectedLimit
+                            new String[0],                                                                          // expectedSelectionArgs
+                            "table.column ASC",                                                                     // expectedOrderBy
+                            0,                                                                                      // expectedOffset
+                            10                                                                                      // expectedLimit
                     },
                     {   // 02: limit provided by last with no offset--should flip ordering in inner select for update/delete query
                             new MockUriBuilder("table")
-                                    .last(10)
+                                    .limit(10)
+                                    .queryFromBottom()
                                     .orderBy(" ORDER BY table.column ASC")
-                                    .build(),                                                  // inputUri
+                                    .build(),                                                                       // inputUri
                             "table.rowid IN (SELECT table.rowid FROM table ORDER BY table.column DESC LIMIT 10)",   // expectedSelectionRetrieval
                             "table.rowid IN (SELECT table.rowid FROM table ORDER BY table.column DESC LIMIT 10)",   // expectedSelectionEdit
-                            new String[0],                                                                      // expectedSelectionArgs
-                            "table.column ASC",                                                                 // expectedOrderBy
-                            0,                                                                                  // expectedOffset
-                            10                                                                                  // expectedLimit
+                            new String[0],                                                                          // expectedSelectionArgs
+                            "table.column ASC",                                                                     // expectedOrderBy
+                            0,                                                                                      // expectedOffset
+                            10                                                                                      // expectedLimit
                     },
                     {   // 03: no order by clause and no offset should order by _id
                             new MockUriBuilder("table")
-                                    .first(10)
-                                    .build(),                                              // inputUri
-                            "",                                                                             // expectedSelectionRetrieval
+                                    .limit(10)
+                                    .build(),                                                                   // inputUri
+                            "",                                                                                 // expectedSelectionRetrieval
                             "table.rowid IN (SELECT table.rowid FROM table ORDER BY table._id ASC LIMIT 10)",   // expectedSelectionEdit
-                            new String[0],                                                                  // expectedSelectionArgs
-                            "",                                                                             // expectedOrderBy
-                            0,                                                                              // expectedOffset
-                            10                                                                              // expectedLimit
+                            new String[0],                                                                      // expectedSelectionArgs
+                            "",                                                                                 // expectedOrderBy
+                            0,                                                                                  // expectedOffset
+                            10                                                                                  // expectedLimit
                     },
                     {   // 04: no order by clause should not be a problem when limiting from last
                             new MockUriBuilder("table")
-                                    .last(10)
-                                    .build(),                                              // inputUri
+                                    .limit(10)
+                                    .queryFromBottom()
+                                    .build(),                                                                   // inputUri
                             "table.rowid IN (SELECT table.rowid FROM table ORDER BY table._id DESC LIMIT 10)",  // expectedSelectionRetrieval
                             "table.rowid IN (SELECT table.rowid FROM table ORDER BY table._id DESC LIMIT 10)",  // expectedSelectionEdit
-                            new String[0],                                                                  // expectedSelectionArgs
-                            "table._id ASC",                                                                // expectedOrderBy
-                            0,                                                                              // expectedOffset
-                            10                                                                              // expectedLimit
+                            new String[0],                                                                      // expectedSelectionArgs
+                            "table._id ASC",                                                                    // expectedOrderBy
+                            0,                                                                                  // expectedOffset
+                            10                                                                                  // expectedLimit
                     },
-                    {   // 05: multiple order by clauses while limiting from first
+                    {   // 05: multiple order by clauses while limiting from limit
                             new MockUriBuilder("table")
-                                    .first(10)
+                                    .limit(10)
                                     .orderBy(" ORDER BY table.column1 ASC, table.column2 DESC")
-                                    .build(),                                                                      // inputUri
-                            "",                                                                                                     // expectedSelectionRetrieval
+                                    .build(),                                                                                           // inputUri
+                            "",                                                                                                         // expectedSelectionRetrieval
                             "table.rowid IN (SELECT table.rowid FROM table ORDER BY table.column1 ASC, table.column2 DESC LIMIT 10)",   // expectedSelectionEdit
-                            new String[0],                                                                                          // expectedSelectionArgs
-                            "table.column1 ASC, table.column2 DESC",                                                                // expectedOrderBy
-                            0,                                                                                                      // expectedOffset
-                            10                                                                                                      // expectedLimit
+                            new String[0],                                                                                              // expectedSelectionArgs
+                            "table.column1 ASC, table.column2 DESC",                                                                    // expectedOrderBy
+                            0,                                                                                                          // expectedOffset
+                            10                                                                                                          // expectedLimit
                     },
                     {   // 06: multiple order by clauses while limiting from last
                             new MockUriBuilder("table")
-                                    .last(10)
+                                    .limit(10)
+                                    .queryFromBottom()
                                     .orderBy(" ORDER BY table.column1 ASC, table.column2 DESC")
-                                    .build(),                                                                      // inputUri
+                                    .build(),                                                                                           // inputUri
                             "table.rowid IN (SELECT table.rowid FROM table ORDER BY table.column1 DESC, table.column2 ASC LIMIT 10)",   // expectedSelectionRetrieval
                             "table.rowid IN (SELECT table.rowid FROM table ORDER BY table.column1 DESC, table.column2 ASC LIMIT 10)",   // expectedSelectionEdit
-                            new String[0],                                                                                          // expectedSelectionArgs
-                            "table.column1 ASC, table.column2 DESC",                                                                // expectedOrderBy
-                            0,                                                                                                      // expectedOffset
-                            10                                                                                                      // expectedLimit
+                            new String[0],                                                                                              // expectedSelectionArgs
+                            "table.column1 ASC, table.column2 DESC",                                                                    // expectedOrderBy
+                            0,                                                                                                          // expectedOffset
+                            10                                                                                                          // expectedLimit
                     },
                     {   // 07: offset clause by itself only affects update/delete queries
                             new MockUriBuilder("table")
                                     .orderBy(" ORDER BY table.column ASC")
                                     .offset(5)
-                                    .build(),                                                  // inputUri
-                            "",                                                                                 // expectedSelectionRetrieval
-                            "table.rowid IN (SELECT table.rowid FROM table ORDER BY table.column ASC OFFSET 5)",    // expectedSelectionEdit
-                            new String[0],                                                                      // expectedSelectionArgs
-                            "table.column ASC",                                                                 // expectedOrderBy
-                            5,                                                                                  // expectedOffset
-                            0                                                                                   // expectedLimit
+                                    .build(),                                                                               // inputUri
+                            "",                                                                                             // expectedSelectionRetrieval
+                            "table.rowid IN (SELECT table.rowid FROM table ORDER BY table.column ASC LIMIT -1 OFFSET 5)",   // expectedSelectionEdit
+                            new String[0],                                                                                  // expectedSelectionArgs
+                            "table.column ASC",                                                                             // expectedOrderBy
+                            5,                                                                                              // expectedOffset
+                            -1                                                                                              // expectedLimit
                     },
-                    {   // 08: limit provided by first with offset--should NOT flip ordering in inner select for update/delete query
+                    {   // 08: limit provided by limit with offset--should NOT flip ordering in inner select for update/delete query
                             new MockUriBuilder("table")
-                                    .first(10)
+                                    .limit(10)
                                     .offset(5)
                                     .orderBy(" ORDER BY table.column ASC")
-                                    .build(),                                                          // inputUri
-                            "",                                                                                         // expectedSelectionRetrieval
+                                    .build(),                                                                               // inputUri
+                            "",                                                                                             // expectedSelectionRetrieval
                             "table.rowid IN (SELECT table.rowid FROM table ORDER BY table.column ASC LIMIT 10 OFFSET 5)",   // expectedSelectionEdit
-                            new String[0],                                                                              // expectedSelectionArgs
-                            "table.column ASC",                                                                         // expectedOrderBy
-                            5,                                                                                          // expectedOffset
-                            10                                                                                          // expectedLimit
+                            new String[0],                                                                                  // expectedSelectionArgs
+                            "table.column ASC",                                                                             // expectedOrderBy
+                            5,                                                                                              // expectedOffset
+                            10                                                                                              // expectedLimit
                     },
                     {   // 09: limit provided by last with offset--should flip ordering in inner select for update/delete query
                             new MockUriBuilder("table")
-                                    .last(10)
+                                    .limit(10)
+                                    .queryFromBottom()
                                     .offset(5)
                                     .orderBy(" ORDER BY table.column ASC")
-                                    .build(),                                                          // inputUri
+                                    .build(),                                                                               // inputUri
                             "table.rowid IN (SELECT table.rowid FROM table ORDER BY table.column DESC LIMIT 10 OFFSET 5)",  // expectedSelectionRetrieval
                             "table.rowid IN (SELECT table.rowid FROM table ORDER BY table.column DESC LIMIT 10 OFFSET 5)",  // expectedSelectionEdit
-                            new String[0],                                                                              // expectedSelectionArgs
-                            "table.column ASC",                                                                         // expectedOrderBy
-                            5,                                                                                          // expectedOffset
-                            10                                                                                          // expectedLimit
+                            new String[0],                                                                                  // expectedSelectionArgs
+                            "table.column ASC",                                                                             // expectedOrderBy
+                            5,                                                                                              // expectedOffset
+                            10                                                                                              // expectedLimit
                     },
                     {   // 10: no order by clause with offset should order by _id
                             new MockUriBuilder("table")
-                                    .first(10)
+                                    .limit(10)
                                     .offset(5)
-                                    .build(),                                                      // inputUri
-                            "",                                                                                     // expectedSelectionRetrieval
+                                    .build(),                                                                           // inputUri
+                            "",                                                                                         // expectedSelectionRetrieval
                             "table.rowid IN (SELECT table.rowid FROM table ORDER BY table._id ASC LIMIT 10 OFFSET 5)",  // expectedSelectionEdit
-                            new String[0],                                                                          // expectedSelectionArgs
-                            "",                                                                                     // expectedOrderBy
-                            5,                                                                                      // expectedOffset
-                            10                                                                                      // expectedLimit
+                            new String[0],                                                                              // expectedSelectionArgs
+                            "",                                                                                         // expectedOrderBy
+                            5,                                                                                          // expectedOffset
+                            10                                                                                          // expectedLimit
                     },
                     {   // 11: no order by clause with offset should order by _id DESC in inner SELECT query and ASC in outer retrieval
                             new MockUriBuilder("table")
-                                    .last(10)
+                                    .limit(10)
+                                    .queryFromBottom()
                                     .offset(5)
-                                    .build(),                                                      // inputUri
+                                    .build(),                                                                           // inputUri
                             "table.rowid IN (SELECT table.rowid FROM table ORDER BY table._id DESC LIMIT 10 OFFSET 5)", // expectedSelectionRetrieval
                             "table.rowid IN (SELECT table.rowid FROM table ORDER BY table._id DESC LIMIT 10 OFFSET 5)", // expectedSelectionEdit
-                            new String[0],                                                                          // expectedSelectionArgs
-                            "table._id ASC",                                                                        // expectedOrderBy
-                            5,                                                                                      // expectedOffset
-                            10                                                                                      // expectedLimit
+                            new String[0],                                                                              // expectedSelectionArgs
+                            "table._id ASC",                                                                            // expectedOrderBy
+                            5,                                                                                          // expectedOffset
+                            10                                                                                          // expectedLimit
                     },
-                    {   // 12: multiple order by clauses with offset while limiting from first
+                    {   // 12: multiple order by clauses with offset while limiting from limit
                             new MockUriBuilder("table")
-                                    .first(10)
+                                    .limit(10)
                                     .offset(5)
                                     .orderBy(" ORDER BY table.column1 ASC, table.column2 DESC")
-                                    .build(),                                                                              // inputUri
-                            "",                                                                                                             // expectedSelectionRetrieval
+                                    .build(),                                                                                                   // inputUri
+                            "",                                                                                                                 // expectedSelectionRetrieval
                             "table.rowid IN (SELECT table.rowid FROM table ORDER BY table.column1 ASC, table.column2 DESC LIMIT 10 OFFSET 5)",  // expectedSelectionEdit
-                            new String[0],                                                                                                  // expectedSelectionArgs
-                            "table.column1 ASC, table.column2 DESC",                                                                        // expectedOrderBy
-                            5,                                                                                                              // expectedOffset
-                            10                                                                                                              // expectedLimit
+                            new String[0],                                                                                                      // expectedSelectionArgs
+                            "table.column1 ASC, table.column2 DESC",                                                                            // expectedOrderBy
+                            5,                                                                                                                  // expectedOffset
+                            10                                                                                                                  // expectedLimit
                     },
                     {   // 13: multiple order by clauses with offset while limiting from last
                             new MockUriBuilder("table")
-                                    .last(10)
+                                    .limit(10)
+                                    .queryFromBottom()
                                     .offset(5)
                                     .orderBy(" ORDER BY table.column1 ASC, table.column2 DESC")
-                                    .build(),                                                                              // inputUri
+                                    .build(),                                                                                                   // inputUri
                             "table.rowid IN (SELECT table.rowid FROM table ORDER BY table.column1 DESC, table.column2 ASC LIMIT 10 OFFSET 5)",  // expectedSelectionRetrieval
                             "table.rowid IN (SELECT table.rowid FROM table ORDER BY table.column1 DESC, table.column2 ASC LIMIT 10 OFFSET 5)",  // expectedSelectionEdit
-                            new String[0],                                                                                                  // expectedSelectionArgs
-                            "table.column1 ASC, table.column2 DESC",                                                                        // expectedOrderBy
-                            5,                                                                                                              // expectedOffset
-                            10                                                                                                              // expectedLimit
+                            new String[0],                                                                                                      // expectedSelectionArgs
+                            "table.column1 ASC, table.column2 DESC",                                                                            // expectedOrderBy
+                            5,                                                                                                                  // expectedOffset
+                            10                                                                                                                  // expectedLimit
                     },
                     {   // 14: single table join uri selecting last
                             new MockUriBuilder("table")
-                                    .last(10)
+                                    .limit(10)
+                                    .queryFromBottom()
                                     .addJoin(FSJoin.Type.INNER, "table", "child_table", "parent_column", "child_column")
                                     .orderBy(" ORDER BY table.column1 ASC, table.column2 DESC")
-                                    .build(),                                                                              // inputUri
+                                    .build(),                                                                                                                                                                   // inputUri
                             "table.rowid IN (SELECT table.rowid FROM table INNER JOIN child_table ON child_table.child_column = table.parent_column ORDER BY table.column1 DESC, table.column2 ASC LIMIT 10)",  // expectedSelectionRetrieval
                             "table.rowid IN (SELECT table.rowid FROM table INNER JOIN child_table ON child_table.child_column = table.parent_column ORDER BY table.column1 DESC, table.column2 ASC LIMIT 10)",  // expectedSelectionEdit
-                            new String[0],                                                                                                  // expectedSelectionArgs
-                            "table.column1 ASC, table.column2 DESC",                                                                        // expectedOrderBy
-                            0,                                                                                                              // expectedOffset
-                            10                                                                                                              // expectedLimit
+                            new String[0],                                                                                                                                                                      // expectedSelectionArgs
+                            "table.column1 ASC, table.column2 DESC",                                                                                                                                            // expectedOrderBy
+                            0,                                                                                                                                                                                  // expectedOffset
+                            10                                                                                                                                                                                  // expectedLimit
                     },
                     {   // 15: multiple table join uri selecting last
                             new MockUriBuilder("table")
-                                    .last(10)
+                                    .limit(10)
+                                    .queryFromBottom()
                                     .addJoin(FSJoin.Type.INNER, "table", "child_table", "parent_column", "child_column")
                                     .addJoin(FSJoin.Type.LEFT, "child_table", "grandchild_table", "child_column2", "grandchild_column")
                                     .orderBy(" ORDER BY table.column1 ASC, table.column2 DESC")
-                                    .build(),                                                                              // inputUri
-                            "table.rowid IN (SELECT table.rowid FROM table INNER JOIN child_table ON child_table.child_column = table.parent_column LEFT JOIN grandchild_table ON grandchild_table.grandchild_column = child_table.child_column2 ORDER BY table.column1 DESC, table.column2 ASC LIMIT 10)",  // expectedSelectionRetrieval
-                            "table.rowid IN (SELECT table.rowid FROM table INNER JOIN child_table ON child_table.child_column = table.parent_column LEFT JOIN grandchild_table ON grandchild_table.grandchild_column = child_table.child_column2 ORDER BY table.column1 DESC, table.column2 ASC LIMIT 10)",  // expectedSelectionEdit
-                            new String[0],                                                                                                  // expectedSelectionArgs
-                            "table.column1 ASC, table.column2 DESC",                                                                        // expectedOrderBy
-                            0,                                                                                                              // expectedOffset
-                            10                                                                                                              // expectedLimit
+                                    .build(),                                                                                                                                                                                                                                                               // inputUri
+                            "table.rowid IN (SELECT table.rowid FROM table INNER JOIN child_table ON child_table.child_column = table.parent_column LEFT JOIN grandchild_table ON grandchild_table.grandchild_column = child_table.child_column2 ORDER BY table.column1 DESC, table.column2 ASC LIMIT 10)", // expectedSelectionRetrieval
+                            "table.rowid IN (SELECT table.rowid FROM table INNER JOIN child_table ON child_table.child_column = table.parent_column LEFT JOIN grandchild_table ON grandchild_table.grandchild_column = child_table.child_column2 ORDER BY table.column1 DESC, table.column2 ASC LIMIT 10)", // expectedSelectionEdit
+                            new String[0],                                                                                                                                                                                                                                                                  // expectedSelectionArgs
+                            "table.column1 ASC, table.column2 DESC",                                                                                                                                                                                                                                        // expectedOrderBy
+                            0,                                                                                                                                                                                                                                                                              // expectedOffset
+                            10                                                                                                                                                                                                                                                                              // expectedLimit
                     },
                     {   // 15: multiple table join uri with multiple join conditions selecting last
                             new MockUriBuilder("table")
-                                    .last(10)
+                                    .limit(10)
+                                    .queryFromBottom()
                                     .addJoin(FSJoin.Type.INNER, "table", "child_table", "parent_column", "child_column", "parent_column2", "child_column2")
                                     .addJoin(FSJoin.Type.LEFT, "child_table", "grandchild_table", "child_column2", "grandchild_column")
                                     .orderBy(" ORDER BY table.column1 ASC, table.column2 DESC")
-                                    .build(),                                                                              // inputUri
-                            "table.rowid IN (SELECT table.rowid FROM table INNER JOIN child_table ON child_table.child_column = table.parent_column AND child_table.child_column2 = table.parent_column2 LEFT JOIN grandchild_table ON grandchild_table.grandchild_column = child_table.child_column2 ORDER BY table.column1 DESC, table.column2 ASC LIMIT 10)",  // expectedSelectionRetrieval
-                            "table.rowid IN (SELECT table.rowid FROM table INNER JOIN child_table ON child_table.child_column = table.parent_column AND child_table.child_column2 = table.parent_column2 LEFT JOIN grandchild_table ON grandchild_table.grandchild_column = child_table.child_column2 ORDER BY table.column1 DESC, table.column2 ASC LIMIT 10)",  // expectedSelectionEdit
-                            new String[0],                                                                                                  // expectedSelectionArgs
-                            "table.column1 ASC, table.column2 DESC",                                                                        // expectedOrderBy
-                            0,                                                                                                              // expectedOffset
-                            10                                                                                                              // expectedLimit
+                                    .build(),                                                                                                                                                                                                                                                                                                                       // inputUri
+                            "table.rowid IN (SELECT table.rowid FROM table INNER JOIN child_table ON child_table.child_column = table.parent_column AND child_table.child_column2 = table.parent_column2 LEFT JOIN grandchild_table ON grandchild_table.grandchild_column = child_table.child_column2 ORDER BY table.column1 DESC, table.column2 ASC LIMIT 10)",    // expectedSelectionRetrieval
+                            "table.rowid IN (SELECT table.rowid FROM table INNER JOIN child_table ON child_table.child_column = table.parent_column AND child_table.child_column2 = table.parent_column2 LEFT JOIN grandchild_table ON grandchild_table.grandchild_column = child_table.child_column2 ORDER BY table.column1 DESC, table.column2 ASC LIMIT 10)",    // expectedSelectionEdit
+                            new String[0],                                                                                                                                                                                                                                                                                                                          // expectedSelectionArgs
+                            "table.column1 ASC, table.column2 DESC",                                                                                                                                                                                                                                                                                                // expectedOrderBy
+                            0,                                                                                                                                                                                                                                                                                                                                      // expectedOffset
+                            10                                                                                                                                                                                                                                                                                                                                      // expectedLimit
                     }
-                    // TODO: test join URIs with respect to the queries that have to get run.
-                    // It is likely that joining when you have filtered with last() will end up crashing
             });
         }
 

--- a/forsuredbandroid/src/testContentProvider/java/com/fsryan/forsuredb/util/MockUriBuilder.java
+++ b/forsuredbandroid/src/testContentProvider/java/com/fsryan/forsuredb/util/MockUriBuilder.java
@@ -13,8 +13,8 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.fsryan.forsuredb.queryable.UriEvaluator.DISTINCT_QUERY_PARAM;
-import static com.fsryan.forsuredb.queryable.UriEvaluator.FIRST_QUERY_PARAM;
-import static com.fsryan.forsuredb.queryable.UriEvaluator.LAST_QUERY_PARAM;
+import static com.fsryan.forsuredb.queryable.UriEvaluator.FROM_BOTTOM_QUERY_PARAM;
+import static com.fsryan.forsuredb.queryable.UriEvaluator.LIMIT_QUERY_PARAM;
 import static com.fsryan.forsuredb.queryable.UriEvaluator.OFFSET_QUERY_PARAM;
 import static com.fsryan.forsuredb.queryable.UriEvaluator.ORDER_BY_QUERY_PARM;
 import static org.mockito.Matchers.eq;
@@ -72,13 +72,13 @@ public class MockUriBuilder {
         return this;
     }
 
-    public MockUriBuilder first(int first) {
-        addQueryParameter(FIRST_QUERY_PARAM, Integer.toString(first));
+    public MockUriBuilder limit(int limit) {
+        addQueryParameter(LIMIT_QUERY_PARAM, Integer.toString(limit));
         return this;
     }
 
-    public MockUriBuilder last(int last) {
-        addQueryParameter(LAST_QUERY_PARAM, Integer.toString(last));
+    public MockUriBuilder queryFromBottom() {
+        addQueryParameter(FROM_BOTTOM_QUERY_PARAM, "");
         return this;
     }
 
@@ -98,7 +98,7 @@ public class MockUriBuilder {
         for (Map.Entry<String, List<String>> queryParamsWithSameKey : queryParamMap.entrySet()) {
             final String key = queryParamsWithSameKey.getKey();
             final List<String> values = queryParamsWithSameKey.getValue();
-            for (int i = values.size() - 1; i >= 0; i--) {  // <-- return first added occurrence of the query parameter
+            for (int i = values.size() - 1; i >= 0; i--) {  // <-- return limit added occurrence of the query parameter
                 when(uri.getQueryParameter(eq(key))).thenReturn(values.get(i));
             }
             when(uri.getQueryParameters(eq(key))).thenReturn(values);


### PR DESCRIPTION
Issue https://github.com/ryansgot/forsuredbandroid/issues/53

## The implmentation is a hack
The cause listed in the issue was correct, but a straightforward fix was not available with the 0.13.0 version of sqlitelib. Additionally, I found that `SQLiteQueryBuilder` doesn't properly detect that `LIMIT -1` is a valid limit meaning "no limit": https://www.sqlite.org/lang_select.html#limitoffset
`If the LIMIT expression evaluates to a negative value, then there is no upper bound on the number of rows returned.`

You should fix sqlitelib and then just use the query building methods there.

## Additionally
The interpretation of LIMIT, OFFSET, and FROM_BOTTOM within the `UriEvaluator` class ad the `ContentProviderQueryable` class was wrong. Thus, there was a lot more to do on the contentprovider flavor as well.